### PR TITLE
Duplication detection

### DIFF
--- a/summaries/analysis/Analyzer.py
+++ b/summaries/analysis/Analyzer.py
@@ -226,7 +226,6 @@ class Analyzer:
                               comparison_method: str = "exact") -> None:
         """
         Function to determine the number of samples where the input and output is the same.
-        This is problematic, since it models
         :param reference_text_column_name: Name of the column that contains the reference text, for a sample.
             This assumes that each sample is structured as a Dict.
         :param summary_text_column_name: Name of the column that contains the summary text.
@@ -238,7 +237,8 @@ class Analyzer:
             but future versions could utilize approximate matchers to be more resilient to, e.g., Unicode issues.
         :return: Nothing is returned, but numbers of affected samples are printed to console.
         """
-
+        # FIXME: This currently will also register samples that are simply two empty strings, which is technically
+        #  already handled by self.is_either_text_empty().
         if comparison_method not in valid_comparison_methods:
             raise ValueError(f"Currently only the following comparison methods are supported: "
                              f"{valid_comparison_methods}")

--- a/summaries/analysis/Analyzer.py
+++ b/summaries/analysis/Analyzer.py
@@ -359,7 +359,6 @@ class Analyzer:
         :param test_set: List of samples, or split of Huggingface dataset, containing test samples.
         :param comparison_method: Which method to use to determine similarity. Currently only supports "exact",
             but future versions could utilize approximate matchers to be more resilient to, e.g., Unicode issues.
-        :param print_cutoff: Maximum number of chars to print for leaked texts.
         :return: Number of affected samples is printed to console.
         """
         if comparison_method not in valid_comparison_methods:


### PR DESCRIPTION
This PR adds functions to analyze the existence of duplications in a dataset.
Notably, this does *not* attempt to remove such duplicates, since the exact procedure is ambiguous (see #34).

In summary, there are the following functions and additions:
- Addition of a `cutoff_length` parameter to the general `Analyzer` class, giving the option to limit the console output. This is necessary since some the duplication detection works by printing out affected samples (given that datasets need not have a unique identifier for each sample, this is the only way to communicate duplicates effectively without converting to dataframes internally).
- `find_identity_samples`, which will print samples where reference text and summary are the exact same. Currently, this overlaps with the edge case of `is_either_text_empty`, in the case of both texts being empty. However, this is no practical problem, since both cases should be ignored anyways.
- `detect_leakage`, which will scan for duplicate references (or summaries) *across* different dataset splits. Generally, no split is required, but sensible results in this function will only be obtained by passing two ore more splits (e.g., train and test, or validation and test). This is sensible since some datasets only contain particular splits, e.g., during shared tasks etc.
- `detect_duplicates` works as an extension of `detect_leakage`, but also prints out intra-split duplicate references/summaries, i.e., with two samples in the train set having the same text. Internally calls `detect_leakage` to print inter-split duplicates.
