### PR TITLE
Adding differentiation in how to count duplicates

### DIFF
--- a/experiments/german_summarization_datasets/klexikon/clean_klexikon.py
+++ b/experiments/german_summarization_datasets/klexikon/clean_klexikon.py
@@ -1,10 +1,9 @@
 """
 Verify that the cleaner works as intended, and look for issues in Klexikon.
 """
-
+from typing import Dict
 from datasets import load_dataset
-from summaries.preprocessing import Cleaner
-from summaries.analysis import Analyzer
+from summaries import Analyzer, Cleaner
 
 
 def fuse_sentences_but_keep_sample(sample):
@@ -14,16 +13,33 @@ def fuse_sentences_but_keep_sample(sample):
     return sample
 
 
+def custom_print_details(summary: str, reference: str, full_sample: Dict,
+                         filter_reason: str, analyzer: Analyzer, split: str) \
+        -> None:
+    """
+    Example of a print_details function implementation.
+    This will print the reference and summary if the sample has been filtered out for any reason.
+    """
+
+    if filter_reason == "duplicate":
+        print(f"Split: {split}")
+        print(f"u_id: {full_sample['u_id']}, title: {full_sample['title']}, wiki_url: {full_sample['wiki_url']}, "
+              f"klexikon_url: {full_sample['klexikon_url']}")
+
+        print(f"{full_sample}")
+
+
 if __name__ == '__main__':
     klexikon = load_dataset("dennlinger/klexikon")
 
     analyzer = Analyzer(lemmatize=True, lang="de")
     cleaner = Cleaner(analyzer, min_length_summary=20, min_length_reference=50, length_metric="char",
-                      extractiveness=(0.10, 0.90))
-                      # extractiveness="fully")
+                      # extractiveness=(0.10, 0.90))
+                      extractiveness="fully")
 
     train = [fuse_sentences_but_keep_sample(sample) for sample in klexikon["train"]]
     validation = [fuse_sentences_but_keep_sample(sample) for sample in klexikon["validation"]]
     test = [fuse_sentences_but_keep_sample(sample) for sample in klexikon["test"]]
 
-    clean_klexikon = cleaner.clean_dataset("klexikon_text", "wiki_text", train, validation, test, enable_tqdm=True)
+    clean_klexikon = cleaner.clean_dataset("klexikon_text", "wiki_text", train, validation, test, enable_tqdm=True,
+                                           print_details=custom_print_details)


### PR DESCRIPTION
As discussed with Svea Klaus from the EUR-LexSum dataset, it will be helpful to know which kind of duplication may occur.

Now introduces four types:

1. `exact_duplicate`, where the exact combination of `(reference, summary)` has been encountered before.
2. `both_duplicate`, where both the reference and summary have been encountered before, but separately and not together.
3. `reference_duplicate`, where only the reference has been encountered before.
4. `summary_duplicate`, where only the summary has been encountered before.